### PR TITLE
Updates front-end with new function urls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     ports:
       - '1234:1234'
     volumes:
+      - './front-end/Cargo.toml:/usr/src/app/Cargo.toml'
+      - './front-end/Cargo.lock:/usr/src/app/Cargo.lock'
       - './front-end/src:/usr/src/app/src'
       - './front-end/index.html:/usr/src/app/index.html'
       - './front-end/style.css:/usr/src/app/style.css'

--- a/front-end/Dockerfile
+++ b/front-end/Dockerfile
@@ -7,6 +7,7 @@ RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
 WORKDIR /usr/src/app
 
+ENV NODE_ENV=development
 COPY package*.json ./
 RUN npm install
 

--- a/front-end/src/highscores.rs
+++ b/front-end/src/highscores.rs
@@ -45,7 +45,7 @@ pub async fn fetch_highscores() -> Result<Vec<HighScore>, JsValue> {
 
     let base_url = base_url();
     console::log_1(&format!("using highscore api url: {}", base_url).into());
-    let endpoint = format!("{}/api/HighScoreFetcher", base_url);
+    let endpoint = format!("{}/api/topten", base_url);
 
     let request = Request::new_with_str_and_init(&endpoint, &options)?;
 
@@ -88,7 +88,7 @@ pub async fn check_and_submit_highscore(score: usize) -> Result<(), JsValue> {
         options.mode(RequestMode::Cors);
         options.body(Some(&json.into()));
 
-        let endpoint = format!("{}/api/HighScorePoster", base_url());
+        let endpoint = format!("{}/api/submit", base_url());
 
         let request = Request::new_with_str_and_init(&endpoint, &options)?;
 


### PR DESCRIPTION
I was thinking the F# fn's from #17 would be added in addition to the C# functions from earlier,
and I could manually delete the C# fn's after verifying that everything worked.

But the C# functions where removed by #17's deployment,
soooo this should fix front-end asking the wrong endpoints ATM