### PR TITLE
Update highscore-api to dotnet 5 and out-of-process azure functions

### DIFF
--- a/.github/workflows/highscore_functions.yml
+++ b/.github/workflows/highscore_functions.yml
@@ -50,10 +50,13 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: function-output
+          path: function-output
+
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+
       - uses: azure/functions-action@v1
         with:
           app-name: visnakehighscores
-          package: output
+          package: function-output

--- a/.github/workflows/highscore_functions.yml
+++ b/.github/workflows/highscore_functions.yml
@@ -45,7 +45,7 @@ jobs:
   deploy:
     needs: build-and-test
     runs-on: ubuntu-latest
-      #if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/highscore_functions.yml
+++ b/.github/workflows/highscore_functions.yml
@@ -13,42 +13,47 @@ on:
       - .github/workflows/highscore_functions.yml
 
 jobs:
-  build:
-    if: github.event_name == 'pull_request'
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-      - name: Run dotnet build
-        run: |
-          cd highscore-api/HighScoreApi
-          dotnet build
-      - name: Run dotnet test
+
+      - name: Run tests
         run: |
           cd highscore-api/HighScoreApi.Tests
           dotnet test
-  build-and-deploy:
-    if: github.event_name == 'push'
+
+      - name: Build with docker
+        run: |
+          cd highscore-api/HighScoreApi
+          docker build -t highscoreapi .
+
+      # Running custom docker containers as azure functions require premium plans
+      # thus we extract the files and upload, instead of shipping the container image
+      - name: Extract deploy artifacts from docker image
+        run: |
+          container=$(docker create highscoreapi)
+          docker cp $container:/home/site/wwwroot output
+
+      - name: Upload deploy artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: function-output
+          path: output
+          retention-days: 5
+
+  deploy:
+    needs: build-and-test
     runs-on: ubuntu-latest
+      #if: github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/download-artifact@v2
         with:
-          dotnet-version: '3.1.x'
-      - name: Run dotnet build
-        run: |
-          cd highscore-api/HighScoreApi
-          dotnet build --configuration Release --output ./output
-      - name: Run dotnet test
-        run: |
-          cd highscore-api/HighScoreApi.Tests
-          dotnet test
+          name: function-output
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - uses: azure/functions-action@v1
         with:
           app-name: visnakehighscores
-          package: highscore-api/HighScoreApi/output
+          package: output

--- a/highscore-api/HighScoreApi.Tests/HighScoreApi.Tests.fsproj
+++ b/highscore-api/HighScoreApi.Tests/HighScoreApi.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,10 +9,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FsUnit.xUnit" Version="4.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="FsUnit.xUnit" Version="4.0.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/highscore-api/HighScoreApi/Common.fs
+++ b/highscore-api/HighScoreApi/Common.fs
@@ -37,9 +37,9 @@ module DbUtils =
     type SqlScoreHandler() =
         inherit SqlMapper.TypeHandler<Score>()
 
-        override __.SetValue(param, value) = param.Value <- value |> Score.value
+        override _.SetValue(param, value) = param.Value <- value |> Score.value
 
-        override __.Parse value =
+        override _.Parse value =
             let value = value :?> int
 
             match value |> Score.create with
@@ -69,8 +69,7 @@ module DbUtils =
                     |> Async.AwaitTask
 
                 return Ok res
-            with
-            | ex -> return Error ex
+            with ex -> return Error ex
         }
 
 module WebUtils =
@@ -79,12 +78,10 @@ module WebUtils =
 
     /// Create response with CORS header set to allow all origins.
     /// Work-around for bad CORS support in Azure functions docker containers
-    let resWithOkCors (status: HttpStatusCode) (req: HttpRequestData) =
+    let resWithOkCors (status: HttpStatusCode) (req: HttpRequestData) : HttpResponseData =
         let res = req.CreateResponse(status)
         res.Headers.Add("Access-Control-Allow-Origin", "*")
         res
 
-    let okResWithOkCors (req: HttpRequestData) = resWithOkCors HttpStatusCode.OK req
-
-    let badReqWithOkCors (req: HttpRequestData) =
-        resWithOkCors HttpStatusCode.BadRequest req
+    let okResWithOkCors : HttpRequestData -> HttpResponseData = resWithOkCors HttpStatusCode.OK
+    let badReqWithOkCors : HttpRequestData -> HttpResponseData = resWithOkCors HttpStatusCode.BadRequest

--- a/highscore-api/HighScoreApi/Common.fs
+++ b/highscore-api/HighScoreApi/Common.fs
@@ -69,5 +69,22 @@ module DbUtils =
                     |> Async.AwaitTask
 
                 return Ok res
-            with ex -> return Error ex
+            with
+            | ex -> return Error ex
         }
+
+module WebUtils =
+    open System.Net
+    open Microsoft.Azure.Functions.Worker.Http
+
+    /// Create response with CORS header set to allow all origins.
+    /// Work-around for bad CORS support in Azure functions docker containers
+    let resWithOkCors (status: HttpStatusCode) (req: HttpRequestData) =
+        let res = req.CreateResponse(status)
+        res.Headers.Add("Access-Control-Allow-Origin", "*")
+        res
+
+    let okResWithOkCors (req: HttpRequestData) = resWithOkCors HttpStatusCode.OK req
+
+    let badReqWithOkCors (req: HttpRequestData) =
+        resWithOkCors HttpStatusCode.BadRequest req

--- a/highscore-api/HighScoreApi/DbCleanup.fs
+++ b/highscore-api/HighScoreApi/DbCleanup.fs
@@ -3,8 +3,8 @@ namespace HighScoreApi
 open System
 open Dapper
 open FSharp.Data.LiteralProviders
+open Microsoft.Azure.Functions.Worker
 open Microsoft.Data.SqlClient
-open Microsoft.Azure.WebJobs
 open Microsoft.Extensions.Logging
 
 open Common.DbUtils
@@ -13,18 +13,23 @@ module DbCleanup =
     // Run every sunday unless otherwise specified AT COMPILE TIME
     [<Literal>]
     let Schedule =
-        Env<"CRON_CLEANUP_SCHEDULE", "0 0 0 * * SUN">.Value
+        Env<"CRON_CLEANUP_SCHEDULE", "0 0 0 * * SUN">
+            .Value
 
     let removeNonTopHighScores connString =
         use conn = new SqlConnection(connString)
-        conn.Execute "with ToDelete as (
+
+        conn.Execute
+            "with ToDelete as (
                 select * from [highscores]
                 order by [Score] desc, [TimeStamp] asc
                 offset 15 rows)
             delete from ToDelete;"
 
-    [<FunctionName("CleanupJob")>]
-    let run ([<TimerTrigger(Schedule)>] myTimer: TimerInfo, log: ILogger) =
+    [<Function("CleanupJob")>]
+    let run ([<TimerTrigger(Schedule)>] myTimer: TimerInfo, ctx: FunctionContext) =
+        let log = ctx.GetLogger()
+
         sprintf "Database clean-up triggered at: %A" DateTime.Now
         |> log.LogInformation
 

--- a/highscore-api/HighScoreApi/Dockerfile
+++ b/highscore-api/HighScoreApi/Dockerfile
@@ -1,17 +1,17 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS installer-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS installer-env
+# Build requires 3.1 SDK too
+COPY --from=mcr.microsoft.com/dotnet/sdk:3.1 /usr/share/dotnet /usr/share/dotnet
+
 ARG CRON_CLEANUP_SCHEDULE
 ENV CRON_CLEANUP_SCHEDULE $CRON_CLEANUP_SCHEDULE
 
-COPY . /src/dotnet-function-app
-RUN cd /src/dotnet-function-app && \
-    mkdir -p /home/site/wwwroot && \
-    dotnet restore *.fsproj && \
-    dotnet publish *.fsproj --output /home/site/wwwroot
+WORKDIR /src/dotnet-function-app
+COPY HighScoreApi.fsproj .
+RUN dotnet restore *.fsproj
+COPY . .
+RUN dotnet publish *.fsproj --output /home/site/wwwroot
 
-# To enable ssh & remote debugging on app service change the base image to the one below
-# FROM mcr.microsoft.com/azure-functions/dotnet:3.0-appservice
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0
-ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
-    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
-
+FROM mcr.microsoft.com/azure-functions/dotnet-isolated:3.0-dotnet-isolated5.0
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot
+ENV AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 COPY --from=installer-env ["/home/site/wwwroot", "/home/site/wwwroot"]

--- a/highscore-api/HighScoreApi/HighScoreApi.fsproj
+++ b/highscore-api/HighScoreApi/HighScoreApi.fsproj
@@ -2,9 +2,11 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-	<OutputType>Exe</OutputType>
-	<_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
-	<RootNamespace>HighScoreApi</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+    <RootNamespace>HighScoreApi</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<noWarn>1591</noWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.*" />

--- a/highscore-api/HighScoreApi/HighScoreApi.fsproj
+++ b/highscore-api/HighScoreApi/HighScoreApi.fsproj
@@ -1,16 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+	<OutputType>Exe</OutputType>
+	<_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+	<RootNamespace>HighScoreApi</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="dapper" Version="2.0.35" />
-    <PackageReference Include="polly" Version="7.2.1" />
-    <PackageReference Include="FSharp.Data.LiteralProviders" Version="0.2.7" />
-    <PackageReference Include="FSharp.SystemTextJson" Version="0.11.13" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.1.4" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
+    <PackageReference Include="Dapper" Version="2.0.*" />
+    <PackageReference Include="polly" Version="7.2.*" />
+    <PackageReference Include="FSharp.Data.LiteralProviders" Version="0.3.*" />
+    <PackageReference Include="FSharp.SystemTextJson" Version="0.17.*" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.3.*" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.*" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.*" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.1.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common.fs" />
@@ -18,14 +24,11 @@
     <Compile Include="DbCleanup.fs" />
     <Compile Include="TopTen.fs" />
     <Compile Include="Submit.fs" />
+	<Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="host.json">
+    <None Include="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
 </Project>

--- a/highscore-api/HighScoreApi/Program.fs
+++ b/highscore-api/HighScoreApi/Program.fs
@@ -1,5 +1,9 @@
 namespace HighScoreApi
 
+open System.Text.Json
+open System.Text.Json.Serialization
+open Azure.Core.Serialization
+open Microsoft.Azure.Functions.Worker
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting
@@ -11,7 +15,11 @@ module App =
         let builder =
             Host
                 .CreateDefaultBuilder()
-                .ConfigureFunctionsWorkerDefaults()
+                .ConfigureFunctionsWorkerDefaults(fun builder ->
+                    builder.Services.Configure<JsonSerializerOptions>
+                        (fun (options: JsonSerializerOptions) ->
+                            options.PropertyNamingPolicy <- JsonNamingPolicy.CamelCase)
+                    |> ignore)
                 .ConfigureAppConfiguration(fun builder -> builder.AddEnvironmentVariables() |> ignore)
 
         let host = builder.Build()

--- a/highscore-api/HighScoreApi/Program.fs
+++ b/highscore-api/HighScoreApi/Program.fs
@@ -1,0 +1,25 @@
+namespace HighScoreApi
+
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Hosting
+
+module App =
+
+    [<EntryPoint>]
+    let main _ =
+        let builder =
+            Host
+                .CreateDefaultBuilder()
+                .ConfigureFunctionsWorkerDefaults()
+                .ConfigureAppConfiguration(fun builder -> builder.AddEnvironmentVariables() |> ignore)
+
+        let host = builder.Build()
+
+        async {
+            do! Async.SwitchToThreadPool()
+            do! host.RunAsync() |> Async.AwaitTask
+        }
+        |> Async.RunSynchronously
+
+        0

--- a/highscore-api/HighScoreApi/Program.fs
+++ b/highscore-api/HighScoreApi/Program.fs
@@ -1,9 +1,6 @@
 namespace HighScoreApi
 
 open System.Text.Json
-open System.Text.Json.Serialization
-open Azure.Core.Serialization
-open Microsoft.Azure.Functions.Worker
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting

--- a/highscore-api/HighScoreApi/Submit.fs
+++ b/highscore-api/HighScoreApi/Submit.fs
@@ -9,7 +9,6 @@ open Microsoft.Azure.Functions.Worker
 open Microsoft.Azure.Functions.Worker.Http
 open Microsoft.Data.SqlClient
 open Microsoft.Extensions.Logging
-open Microsoft.Extensions.Primitives
 
 open Common.DbUtils
 open Common.WebUtils

--- a/highscore-api/HighScoreApi/Submit.fs
+++ b/highscore-api/HighScoreApi/Submit.fs
@@ -1,13 +1,12 @@
 namespace HighScoreApi
 
 open Dapper
+open System.Net
 open System.IO
 open System.Text.Json
 open System.Text.Json.Serialization
-open Microsoft.AspNetCore.Mvc
-open Microsoft.Azure.WebJobs
-open Microsoft.Azure.WebJobs.Extensions.Http
-open Microsoft.AspNetCore.Http
+open Microsoft.Azure.Functions.Worker
+open Microsoft.Azure.Functions.Worker.Http
 open Microsoft.Data.SqlClient
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Primitives
@@ -27,10 +26,11 @@ module Submit =
     let persist (connection: SqlConnection) highscore =
         async {
             let! rows =
-                connection.ExecuteAsync
-                    ("insert into [highscores]([UserName], [Score], [TimeStamp])
+                connection.ExecuteAsync(
+                    "insert into [highscores]([UserName], [Score], [TimeStamp])
                  values (@UserName, @Score, @TimeStamp)",
-                     highscore)
+                    highscore
+                )
                 |> Async.AwaitTask
 
             do! connection.CloseAsync() |> Async.AwaitTask
@@ -38,39 +38,40 @@ module Submit =
             return rows
         }
 
-    [<FunctionName("Submit")>]
-    let run ([<HttpTrigger(AuthorizationLevel.Anonymous, "post", "options", Route = null)>] req: HttpRequest)
-            (log: ILogger)
-            =
+    [<Function("Submit")>]
+    let run
+        ([<HttpTrigger(AuthorizationLevel.Anonymous, "post", "options", Route = null)>] req: HttpRequestData)
+        (ctx: FunctionContext)
+        =
+        let log = ctx.GetLogger()
+
         async {
             sprintf "Submit triggered with method %A" req.Method
             |> log.LogInformation
 
-            // It is not yet possible to configure CORS for az functions locally in containers
-            // so we just fix headers (ref https://github.com/Azure/azure-functions-host/issues/5090)
-            req.HttpContext.Response.Headers.Add("Access-Control-Allow-Origin", StringValues "*")
+            use stream = new StreamReader(req.Body)
+            let! body = stream.ReadToEndAsync() |> Async.AwaitTask
 
-            // We also need to handle CORS pre-flight requests (Would be automatic on Azure)
-            if req.Method.ToLower() = "options" then
-                return OkResult() :> IActionResult
-            else
-                use stream = new StreamReader(req.Body)
-                let! body = stream.ReadToEndAsync() |> Async.AwaitTask
+            match deserialize body |> toHighScore with
+            | Ok highscore ->
+                sprintf "persisting %A" highscore
+                |> log.LogInformation
 
-                match deserialize body |> toHighScore with
-                | Ok highscore ->
-                    sprintf "persisting %A" highscore
-                    |> log.LogInformation
+                let! rows = persist (connString |> dbConnection) highscore
 
-                    let! rows = persist (connString |> dbConnection) highscore
+                sprintf "%d rows affected" rows
+                |> log.LogInformation
 
-                    sprintf "%d rows affected" rows
-                    |> log.LogInformation
+                return req.CreateResponse(HttpStatusCode.OK)
+            | Error e ->
+                sprintf "%A" e |> log.LogError
 
-                    return OkResult() :> IActionResult
-                | Error e ->
-                    sprintf "%A" e |> log.LogError
-                    return BadRequestObjectResult(sprintf "An error occured: %A" e) :> IActionResult
+                let res =
+                    req.CreateResponse(HttpStatusCode.BadRequest)
 
+                sprintf "An error occured: %A" e
+                |> res.WriteString
+
+                return res
         }
         |> Async.StartAsTask

--- a/highscore-api/HighScoreApi/TopTen.fs
+++ b/highscore-api/HighScoreApi/TopTen.fs
@@ -8,6 +8,7 @@ open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Primitives
 
 open Common.DbUtils
+open Common.WebUtils
 open Common.Dto.HighScoreDto
 open Common.Types
 
@@ -44,7 +45,7 @@ module TopTen =
                     |> sprintf "%d scores retrieved successfully"
                     |> log.LogInformation
 
-                    let res = req.CreateResponse(HttpStatusCode.OK)
+                    let res = okResWithOkCors req
 
                     res
                         .WriteAsJsonAsync(Seq.map fromHighScore scores)

--- a/highscore-api/HighScoreApi/TopTen.fs
+++ b/highscore-api/HighScoreApi/TopTen.fs
@@ -1,11 +1,9 @@
 namespace HighScoreApi
 
-open System.Net
 open Microsoft.Azure.Functions.Worker
 open Microsoft.Azure.Functions.Worker.Http
 open Microsoft.Data.SqlClient
 open Microsoft.Extensions.Logging
-open Microsoft.Extensions.Primitives
 
 open Common.DbUtils
 open Common.WebUtils


### PR DESCRIPTION
Also, one change is done outside of the git repo:

FUNCTIONS_WORKER_RUNTIME configuration/environment variable is changed from `dotnet` to `dotnet-isolated`