### PR TITLE
[wip] add IaC with terraform

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,43 @@
+name: terraform
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - terraform/**
+      - .github/workflows/terraform.yml
+  pull_request:
+    branches: [master]
+    paths:
+      - terraform/**
+      - .github/workflows/terraform.yml
+
+env:
+  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+
+jobs:
+  plan_apply:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: terraform
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Init
+        run: |
+          terraform -v
+          terraform init --input=false
+
+      - name: Validate
+        run: terraform validate
+
+      - name: Plan
+        run: terraform plan --input=false --refresh=true --lock=false --out "release.tfplan"
+
+      - name: Apply
+        run: terraform apply --input=false release.tfplan

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - terraform/**
       - .github/workflows/terraform.yml
+  workflow_dispatch:
 
 env:
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,8 +2,24 @@
 
 Provisions infrastructure needed for our webapp / api.
 
-**Note on database**
-I would like to provision the database here to.
-Unfortunately creating free tier (M0) MongoDB clusters is not supported
-by MongoDB API/terraform provider, and therefore I create it manually on
-mongodb.com instead.
+### Initial infrastructure required for terraform state management
+
+A resource group, storage account and storage container must be provisioned
+manually for state management.
+
+Something like this
+```sh
+az group create --name rg-snake-prod --location norwayeast
+az storage account create --name stsnakeprod --resource-group rg-snake-prod
+az storage container create --account-name stsnakeprod --name tfstate
+```
+
+### Running locally
+
+Requires having access to the subscription/resource group.
+
+```sh
+az login
+az account set -s <azure-subscription>
+terraform init
+```

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -13,8 +13,8 @@ resource "azurerm_app_service_plan" "apiPlan" {
   tags = local.common_tags
 }
 
-resource "azurerm_function_app" "api" {
-  name                       = "func-snake-${var.ENVIRONMENT}"
+resource "azurerm_function_app" "highScoreApi" {
+  name                       = "func-snakehighscores-${var.ENVIRONMENT}"
   location                   = data.azurerm_resource_group.rg.location
   resource_group_name        = data.azurerm_resource_group.rg.name
   app_service_plan_id        = azurerm_app_service_plan.apiPlan.id

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -1,0 +1,40 @@
+resource "azurerm_app_service_plan" "apiPlan" {
+  name                = "asp-snake-${var.ENVIRONMENT}"
+  location            = data.azurerm_resource_group.rg.location
+  resource_group_name = data.azurerm_resource_group.rg.name
+  kind                = "Linux"
+  reserved            = true
+
+  sku {
+    tier = "Dynamic"
+    size = "Y1"
+  }
+
+  tags = local.common_tags
+}
+
+resource "azurerm_function_app" "api" {
+  name                       = "func-snake-${var.ENVIRONMENT}"
+  location                   = data.azurerm_resource_group.rg.location
+  resource_group_name        = data.azurerm_resource_group.rg.name
+  app_service_plan_id        = azurerm_app_service_plan.apiPlan.id
+  storage_account_name       = data.azurerm_storage_account.st.name
+  storage_account_access_key = data.azurerm_storage_account.st.primary_access_key
+  os_type                    = "linux"
+  version                    = "~3"
+
+  app_settings = {
+    "CONNECTION_STRING"        = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.mongoConnectionString.id})"
+    "FUNCTIONS_WORKER_RUNTIME" = "dotnet-isolated"
+  }
+
+  site_config {
+    ftps_state = "Disabled"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = local.common_tags
+}

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -2,7 +2,7 @@ resource "azurerm_app_service_plan" "apiPlan" {
   name                = "asp-snake-${var.ENVIRONMENT}"
   location            = "West Europe" # Norway not yet supported for func with Linux consumption plan
   resource_group_name = data.azurerm_resource_group.rg.name
-  kind                = "Linux"
+  kind                = "FunctionApp"
   reserved            = true
 
   sku {

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -1,6 +1,6 @@
 resource "azurerm_app_service_plan" "apiPlan" {
   name                = "asp-snake-${var.ENVIRONMENT}"
-  location            = data.azurerm_resource_group.rg.location
+  location            = "West Europe" # Norway not yet supported for func with Linux consumption plan
   resource_group_name = data.azurerm_resource_group.rg.name
   kind                = "Linux"
   reserved            = true
@@ -15,8 +15,8 @@ resource "azurerm_app_service_plan" "apiPlan" {
 
 resource "azurerm_function_app" "highScoreApi" {
   name                       = "func-snakehighscores-${var.ENVIRONMENT}"
-  location                   = data.azurerm_resource_group.rg.location
-  resource_group_name        = data.azurerm_resource_group.rg.name
+  location                   = azurerm_app_service_plan.apiPlan.location
+  resource_group_name        = azurerm_app_service_plan.apiPlan.resource_group_name
   app_service_plan_id        = azurerm_app_service_plan.apiPlan.id
   storage_account_name       = data.azurerm_storage_account.st.name
   storage_account_access_key = data.azurerm_storage_account.st.primary_access_key

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,12 +1,13 @@
-resource "azurerm_static_site" "app" {
-  name                = "stapp-snake-${var.ENVIRONMENT}"
-  resource_group_name = data.azurerm_resource_group.rg.name
-  location            = "West Europe" # Norway not yet supported for azure static webapp
-  default_host_name   = "snake-${var.ENVIRONMENT}.azurestaticapps.net"
-  sku_tier            = "Standard" # Free tier does not support bring-your-own functions
-  sku_size            = "Standard" # Free tier does not support bring-your-own functions
-  tags                = local.common_tags
-}
+# BLOCKED BY https://github.com/terraform-providers/terraform-provider-azurerm/issues/12610
+#resource "azurerm_static_site" "app" {
+#  name                = "stapp-snake-${var.ENVIRONMENT}"
+#  resource_group_name = data.azurerm_resource_group.rg.name
+#  location            = "West Europe" # Norway not yet supported for azure static webapp
+#  default_host_name   = "snake-${var.ENVIRONMENT}.azurestaticapps.net"
+#  sku_tier            = "Standard" # Free tier does not support bring-your-own functions
+#  sku_size            = "Standard" # Free tier does not support bring-your-own functions
+#  tags                = local.common_tags
+#}
 
 # Manual Steps
 # - Associate with GitHub target repository

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,0 +1,10 @@
+resource "azurerm_static_site" "site" {
+  name                = "stapp-snake-${var.ENVIRONMENT}"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = "West Europe" # norway not yet supported
+  tags                = local.common_tags
+}
+
+# TODO / Manual Step
+# Linking function app and static web app together is not yet possible as IaC
+# Done manually in the portal following https://docs.microsoft.com/en-us/azure/static-web-apps/functions-bring-your-own

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,7 +1,7 @@
-resource "azurerm_static_site" "site" {
+resource "azurerm_static_site" "app" {
   name                = "stapp-snake-${var.ENVIRONMENT}"
   resource_group_name = data.azurerm_resource_group.rg.name
-  location            = "West Europe" # norway not yet supported
+  location            = "West Europe" # Norway not yet supported for azure static webapp
   tags                = local.common_tags
 }
 

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -2,9 +2,13 @@ resource "azurerm_static_site" "app" {
   name                = "stapp-snake-${var.ENVIRONMENT}"
   resource_group_name = data.azurerm_resource_group.rg.name
   location            = "West Europe" # Norway not yet supported for azure static webapp
+  default_host_name   = "snake-${var.ENVIRONMENT}.azurestaticapps.net"
+  sku_tier            = "Standard" # Free tier does not support bring-your-own functions
+  sku_size            = "Standard" # Free tier does not support bring-your-own functions
   tags                = local.common_tags
 }
 
-# TODO / Manual Step
-# Linking function app and static web app together is not yet possible as IaC
-# Done manually in the portal following https://docs.microsoft.com/en-us/azure/static-web-apps/functions-bring-your-own
+# Manual Steps
+# - Associate with GitHub target repository
+# - Link function app and static web app together
+#   (https://docs.microsoft.com/en-us/azure/static-web-apps/functions-bring-your-own)

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,24 @@
+data "azurerm_client_config" "current" {}
+
+data "azurerm_resource_group" "rg" {
+  name = "rg-snake-${var.ENVIRONMENT}"
+}
+
+data "azurerm_storage_account" "st" {
+  name                = "stsnake${var.ENVIRONMENT}"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+variable "ENVIRONMENT" {
+  type    = string
+  default = "prod"
+}
+
+locals {
+  common_tags = {
+    Owner       = "Christian Fosli"
+    Application = "snake (hobby project)"
+    Environment = var.ENVIRONMENT
+    CreatedBy   = "terraform"
+  }
+}

--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -5,8 +5,8 @@
 # Move it here if I decide to up the SKU
 
 resource "azurerm_key_vault_secret" "mongoConnectionString" {
+  # value      = "dummyValue"
   name         = "connstring-mongodb"
-  value        = "dummyValue"
   key_vault_id = azurerm_key_vault.vault.id
   tags         = local.common_tags
 }

--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -5,8 +5,14 @@
 # Move it here if I decide to up the SKU
 
 resource "azurerm_key_vault_secret" "mongoConnectionString" {
-  # value      = "dummyValue"
   name         = "connstring-mongodb"
+  value        = "dummyValue"
   key_vault_id = azurerm_key_vault.vault.id
   tags         = local.common_tags
+
+  lifecycle {
+    # Set the secret value to the correct connecton string manually outside of terraform
+    # If we provision the DB and users as IaC we could track the value here too and remove the ignore_changes
+    ignore_changes = [value]
+  }
 }

--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -5,7 +5,7 @@
 # Move it here if I decide to up the SKU
 
 resource "azurerm_key_vault_secret" "mongoConnectionString" {
-  name         = "mongo-connstring-func-snake"
+  name         = "connstring-mongodb"
   value        = "dummyValue"
   key_vault_id = azurerm_key_vault.vault.id
   tags         = local.common_tags

--- a/terraform/db.tf
+++ b/terraform/db.tf
@@ -1,0 +1,12 @@
+# TODO:
+# I would like to provision the database and database user here.
+# Unfortunately creating free tier (M0) MongoDB clusters is not supported
+# by MongoDB API/terraform provider, and therefore I create it manually on mongodb.com instead.
+# Move it here if I decide to up the SKU
+
+resource "azurerm_key_vault_secret" "mongoConnectionString" {
+  name         = "mongo-connstring-func-snake"
+  value        = "dummyValue"
+  key_vault_id = azurerm_key_vault.vault.id
+  tags         = local.common_tags
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "rg-snake-prod"
+    storage_account_name = "stsnakeprod"
+    container_name       = "tfstate"
+    key                  = "prod.terraform.tfstate"
+  }
+
+  required_providers {
+    azurerm = {
+      version = "~>2.69"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -9,23 +9,25 @@ resource "azurerm_key_vault" "vault" {
 
   sku_name = "standard"
 
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions        = ["Get"]
-    secret_permissions     = ["Get", "Set", "Delete", "Purge", "Recover", "Restore"]
-    cerificate_permissions = ["Get"]
-  }
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = azurerm_function_app.api.identity.0.object_id
-
-    key_permissions        = ["Get"]
-    secret_permissions     = ["Get"]
-    cerificate_permissions = ["Get"]
-  }
-
   tags = local.common_tags
+}
+
+resource "azurerm_key_vault_access_policy" "tfAgent" {
+  key_vault_id = azurerm_key_vault.vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions        = ["Get"]
+  secret_permissions     = ["Get", "Set", "Delete", "Purge", "Recover", "Restore"]
+  cerificate_permissions = ["Get"]
+}
+
+resource "azurerm_key_vault_access_policy" "funcApi" {
+  key_vault_id = azurerm_key_vault.vault.id
+  tenant_id    = azurerm_function_app.api.identity.0.tenant_id
+  object_id    = azurerm_function_app.api.identity.0.object_id
+
+  key_permissions        = ["Get"]
+  secret_permissions     = ["Get"]
+  cerificate_permissions = ["Get"]
 }

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -1,0 +1,31 @@
+resource "azurerm_key_vault" "vault" {
+  name                       = "kv-snake-${var.ENVIRONMENT}"
+  location                   = data.azurerm_resource_group.rg.location
+  resource_group_name        = data.azurerm_resource_group.rg.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = false
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions        = ["Get"]
+    secret_permissions     = ["Get", "Set", "Delete", "Purge", "Recover", "Restore"]
+    cerificate_permissions = ["Get"]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = azurerm_function_app.api.identity.0.object_id
+
+    key_permissions        = ["Get"]
+    secret_permissions     = ["Get"]
+    cerificate_permissions = ["Get"]
+  }
+
+  tags = local.common_tags
+}

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -3,7 +3,6 @@ resource "azurerm_key_vault" "vault" {
   location                   = data.azurerm_resource_group.rg.location
   resource_group_name        = data.azurerm_resource_group.rg.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = false
 
@@ -17,17 +16,17 @@ resource "azurerm_key_vault_access_policy" "tfAgent" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions        = ["Get"]
-  secret_permissions     = ["Get", "Set", "Delete", "Purge", "Recover", "Restore"]
-  cerificate_permissions = ["Get"]
+  key_permissions         = ["Get"]
+  secret_permissions      = ["Get", "Set", "Delete", "Purge", "Recover", "Restore"]
+  certificate_permissions = ["Get"]
 }
 
-resource "azurerm_key_vault_access_policy" "funcApi" {
+resource "azurerm_key_vault_access_policy" "highScoreFunc" {
   key_vault_id = azurerm_key_vault.vault.id
-  tenant_id    = azurerm_function_app.api.identity.0.tenant_id
-  object_id    = azurerm_function_app.api.identity.0.object_id
+  tenant_id    = azurerm_function_app.highScoreApi.identity.0.tenant_id
+  object_id    = azurerm_function_app.highScoreApi.identity.0.principal_id
 
-  key_permissions        = ["Get"]
-  secret_permissions     = ["Get"]
-  cerificate_permissions = ["Get"]
+  key_permissions         = ["Get"]
+  secret_permissions      = ["Get"]
+  certificate_permissions = ["Get"]
 }


### PR DESCRIPTION
Add infrastructure-as-code using terraform.
This creates a new static web app / function app.
Some things are kind of "half done" but better than no IaC :smile:

CD pipelines for function/static-webapp will be updated to target the new ones provisioned here in a later PR.
The old ones created manually can be removed after CD pipelines is moved and DNS record points to the new site.