### PR TITLE
chore: add DNS records and point www.playsnake.no to static web app

### DIFF
--- a/.github/workflows/wasm_app.yml
+++ b/.github/workflows/wasm_app.yml
@@ -39,13 +39,13 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
             echo "BUILD_VERSION=pr_build_$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-            echo "HIGHSCORE_API_BASE_URL=https://func-snakehighscores-staging.azurewebsites.net" >> $GITHUB_ENV
+            echo "HIGHSCORE_API_BASE_URL=https://highscores-staging.playsnake.no" >> $GITHUB_ENV
 
       - name: Set variables for prod
         if: github.event_name != 'pull_request'
         run: |
             echo "BUILD_VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-            echo "HIGHSCORE_API_BASE_URL=https://func-snakehighscores-prod.azurewebsites.net" >> $GITHUB_ENV
+            echo "HIGHSCORE_API_BASE_URL=https://highscores.playsnake.no" >> $GITHUB_ENV
 
       - name: Docker build
         run: |

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -62,3 +62,13 @@ resource "azurerm_app_service_custom_hostname_binding" "highScoreApi" {
   app_service_name    = azurerm_function_app.highScoreApi.name
   resource_group_name = azurerm_function_app.highScoreApi.resource_group_name
 }
+
+resource "azurerm_app_service_managed_certificate" "highScoreApi" {
+  custom_hostname_binding_id = azurerm_app_service_custom_hostname_binding.highScoreApi.id
+}
+
+resource "azurerm_app_service_certificate_binding" "highScoreApi" {
+  hostname_binding_id = azurerm_app_service_custom_hostname_binding.highScoreApi.id
+  certificate_id      = azurerm_app_service_managed_certificate.highScoreApi.id
+  ssl_state           = "SniEnabled"
+}

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -56,3 +56,9 @@ resource "azurerm_function_app" "highScoreApi" {
 
   tags = local.common_tags
 }
+
+resource "azurerm_app_service_custom_hostname_binding" "highScoreApi" {
+  hostname            = trimsuffix(azurerm_dns_cname_record.highScoreApi.fqdn, ".")
+  app_service_name    = azurerm_function_app.highScoreApi.name
+  resource_group_name = azurerm_function_app.highScoreApi.resource_group_name
+}

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -35,7 +35,8 @@ resource "azurerm_function_app" "highScoreApi" {
   }
 
   site_config {
-    ftps_state = "Disabled"
+    ftps_state    = "Disabled"
+    http2_enabled = true
 
     cors {
       allowed_origins     = ["*"]

--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -35,8 +35,9 @@ resource "azurerm_function_app" "highScoreApi" {
   }
 
   site_config {
-    ftps_state    = "Disabled"
-    http2_enabled = true
+    ftps_state                = "Disabled"
+    http2_enabled             = true
+    use_32_bit_worker_process = false
 
     cors {
       allowed_origins     = ["*"]

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -13,3 +13,5 @@ resource "azurerm_static_site" "app" {
 
 # Manual Steps
 # - Associate with GitHub target repository
+# - Add custom domain (May be added to terraform soon)
+#   -> see https://github.com/terraform-providers/terraform-provider-azurerm/issues/11971

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -18,10 +18,10 @@ resource "azurerm_dns_cname_record" "app" {
   target_resource_id  = azurerm_static_site.app[0].id
 }
 
-resource "azurerm_dns_cname_record" "highscoreApi" {
-  name                = var.ENVIRONMENT == "prod" ? "highscores" : "highscores-${var.ENVIRONMENT}"
-  zone_name           = "playsnake.no"  # hardcoded because sometimes different env
-  resource_group_name = "rg-snake-prod" # hardcoded because sometimes different env
-  ttl                 = 300
-  target_resource_id  = azurerm_function_app.highScoreApi.id
-}
+#resource "azurerm_dns_cname_record" "highscoreApi" {
+#  name                = var.ENVIRONMENT == "prod" ? "highscores" : "highscores-${var.ENVIRONMENT}"
+#  zone_name           = "playsnake.no"  # hardcoded because sometimes different env
+#  resource_group_name = "rg-snake-prod" # hardcoded because sometimes different env
+#  ttl                 = 300
+#  target_resource_id  = azurerm_function_app.highScoreApi.id
+#}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -18,10 +18,10 @@ resource "azurerm_dns_cname_record" "app" {
   target_resource_id  = azurerm_static_site.app[0].id
 }
 
-resource "azurerm_dns_cname_record" "highscoreApi" {
+resource "azurerm_dns_cname_record" "highScoreApi" {
   name                = var.ENVIRONMENT == "prod" ? "highscores" : "highscores-${var.ENVIRONMENT}"
   zone_name           = "playsnake.no"  # hardcoded because sometimes different env
   resource_group_name = "rg-snake-prod" # hardcoded because sometimes different env
   ttl                 = 300
-  record              = azurerm_function_app.highscoreApi.default_hostname
+  record              = azurerm_function_app.highScoreApi.default_hostname
 }

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,27 @@
+# DNS doesnt perfectly fit "staging -> prod" lifecycle
+# So it's a little hacky
+
+resource "azurerm_dns_zone" "playsnakePublic" {
+  count = var.ENVIRONMENT == "prod" ? 1 : 0
+
+  name                = "playsnake.no"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+resource "azurerm_dns_cname_record" "app" {
+  count = var.ENVIRONMENT == "prod" ? 1 : 0
+
+  name                = "www"
+  zone_name           = azurerm_dns_zone.playsnakePublic.name
+  resource_group_name = data.azurerm_resource_group.rg.name
+  ttl                 = 300
+  target_resource_id  = azurerm_static_site.app[0].id
+}
+
+resource "azurerm_dns_cname_record" "highscoreApi" {
+  name                = var.ENVIRONMENT == "prod" ? "highscores" : "highscores-${var.ENVIRONMENT}"
+  zone_name           = "playsnake.no"  # hardcoded because sometimes different env
+  resource_group_name = "rg-snake-prod" # hardcoded because sometimes different env
+  ttl                 = 300
+  target_resource_id  = azurerm_function_app.highScoreApi.id
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -18,10 +18,10 @@ resource "azurerm_dns_cname_record" "app" {
   target_resource_id  = azurerm_static_site.app[0].id
 }
 
-#resource "azurerm_dns_cname_record" "highscoreApi" {
-#  name                = var.ENVIRONMENT == "prod" ? "highscores" : "highscores-${var.ENVIRONMENT}"
-#  zone_name           = "playsnake.no"  # hardcoded because sometimes different env
-#  resource_group_name = "rg-snake-prod" # hardcoded because sometimes different env
-#  ttl                 = 300
-#  target_resource_id  = azurerm_function_app.highScoreApi.id
-#}
+resource "azurerm_dns_cname_record" "highscoreApi" {
+  name                = var.ENVIRONMENT == "prod" ? "highscores" : "highscores-${var.ENVIRONMENT}"
+  zone_name           = "playsnake.no"  # hardcoded because sometimes different env
+  resource_group_name = "rg-snake-prod" # hardcoded because sometimes different env
+  ttl                 = 300
+  record              = azurerm_function_app.highscoreApi.default_hostname
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -8,20 +8,20 @@ resource "azurerm_dns_zone" "playsnakePublic" {
   resource_group_name = data.azurerm_resource_group.rg.name
 }
 
-#resource "azurerm_dns_cname_record" "app" {
-#  count = var.ENVIRONMENT == "prod" ? 1 : 0
-#
-#  name                = "www"
-#  zone_name           = azurerm_dns_zone.playsnakePublic.name
-#  resource_group_name = data.azurerm_resource_group.rg.name
-#  ttl                 = 300
-#  target_resource_id  = azurerm_static_site.app[0].id
-#}
-#
-#resource "azurerm_dns_cname_record" "highscoreApi" {
-#  name                = var.ENVIRONMENT == "prod" ? "highscores" : "highscores-${var.ENVIRONMENT}"
-#  zone_name           = "playsnake.no"  # hardcoded because sometimes different env
-#  resource_group_name = "rg-snake-prod" # hardcoded because sometimes different env
-#  ttl                 = 300
-#  target_resource_id  = azurerm_function_app.highScoreApi.id
-#}
+resource "azurerm_dns_cname_record" "app" {
+  count = var.ENVIRONMENT == "prod" ? 1 : 0
+
+  name                = "www"
+  zone_name           = azurerm_dns_zone.playsnakePublic[0].name
+  resource_group_name = azurerm_dns_zone.playsnakePublic[0].resource_group_name
+  ttl                 = 300
+  target_resource_id  = azurerm_static_site.app[0].id
+}
+
+resource "azurerm_dns_cname_record" "highscoreApi" {
+  name                = var.ENVIRONMENT == "prod" ? "highscores" : "highscores-${var.ENVIRONMENT}"
+  zone_name           = "playsnake.no"  # hardcoded because sometimes different env
+  resource_group_name = "rg-snake-prod" # hardcoded because sometimes different env
+  ttl                 = 300
+  target_resource_id  = azurerm_function_app.highScoreApi.id
+}

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -8,20 +8,20 @@ resource "azurerm_dns_zone" "playsnakePublic" {
   resource_group_name = data.azurerm_resource_group.rg.name
 }
 
-resource "azurerm_dns_cname_record" "app" {
-  count = var.ENVIRONMENT == "prod" ? 1 : 0
-
-  name                = "www"
-  zone_name           = azurerm_dns_zone.playsnakePublic.name
-  resource_group_name = data.azurerm_resource_group.rg.name
-  ttl                 = 300
-  target_resource_id  = azurerm_static_site.app[0].id
-}
-
-resource "azurerm_dns_cname_record" "highscoreApi" {
-  name                = var.ENVIRONMENT == "prod" ? "highscores" : "highscores-${var.ENVIRONMENT}"
-  zone_name           = "playsnake.no"  # hardcoded because sometimes different env
-  resource_group_name = "rg-snake-prod" # hardcoded because sometimes different env
-  ttl                 = 300
-  target_resource_id  = azurerm_function_app.highScoreApi.id
-}
+#resource "azurerm_dns_cname_record" "app" {
+#  count = var.ENVIRONMENT == "prod" ? 1 : 0
+#
+#  name                = "www"
+#  zone_name           = azurerm_dns_zone.playsnakePublic.name
+#  resource_group_name = data.azurerm_resource_group.rg.name
+#  ttl                 = 300
+#  target_resource_id  = azurerm_static_site.app[0].id
+#}
+#
+#resource "azurerm_dns_cname_record" "highscoreApi" {
+#  name                = var.ENVIRONMENT == "prod" ? "highscores" : "highscores-${var.ENVIRONMENT}"
+#  zone_name           = "playsnake.no"  # hardcoded because sometimes different env
+#  resource_group_name = "rg-snake-prod" # hardcoded because sometimes different env
+#  ttl                 = 300
+#  target_resource_id  = azurerm_function_app.highScoreApi.id
+#}


### PR DESCRIPTION
* Add DNS records for playsnake.no
  * DNS for playsnake.no is now hosted by azure DNS instead of GoDaddy's default nameserver
  * Point www.playsnake.no to static web app, rather than CDN endpoint from earlier
* Add DNS records and TLS certs for highscore function app