### PR TITLE
test: Add E2E tests with PlayWright

### DIFF
--- a/.github/workflows/highscore_api.yaml
+++ b/.github/workflows/highscore_api.yaml
@@ -61,6 +61,7 @@ jobs:
   deploy_staging:
     needs: build
     runs-on: ubuntu-22.04
+    environment: staging
     steps:
     - uses: actions/checkout@v3
 
@@ -80,6 +81,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: deploy_staging
     runs-on: ubuntu-22.04
+    environment: prod
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/highscore_cleanup_job.yaml
+++ b/.github/workflows/highscore_cleanup_job.yaml
@@ -61,6 +61,7 @@ jobs:
   deploy_staging:
     needs: build
     runs-on: ubuntu-22.04
+    environment: staging
     steps:
     - uses: actions/checkout@v3
 
@@ -80,6 +81,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: deploy_staging
     runs-on: ubuntu-22.04
+    environment: prod
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,6 +25,7 @@ env:
 jobs:
   staging:
     runs-on: ubuntu-22.04
+    environment: staging
     env:
       TF_VAR_ENVIRONMENT: staging
     defaults:
@@ -59,6 +60,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: staging
     runs-on: ubuntu-22.04
+    environment: prod
     env:
       TF_VAR_ENVIRONMENT: prod
     defaults:

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -1,0 +1,46 @@
+name: test_e2e
+
+on:
+  deployment:
+  push:
+    paths:
+      - e2e/**
+      - .github/workflows/test_e2e.yaml
+  schedule:
+    - cron: '0 9 * * SUN'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    name: Test E2E
+
+    defaults:
+      run:
+        working-directory: e2e
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Install browsers
+        run: npx playwright install --with-deps
+
+      - name: Wake up API
+        run: curl -sSf https://highscores.playsnake.no/readyz
+
+      - name: Run tests
+        run: npx playwright test
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7

--- a/.github/workflows/wasm_app.yml
+++ b/.github/workflows/wasm_app.yml
@@ -32,6 +32,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-22.04
     name: Build and Deploy
+    environment: "${{ github.event_name == 'push' && 'prod' || 'staging' }}"
     env:
       DOCKER_BUILDKIT: "1"
     steps:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Visit [playsnake.no](https://www.playsnake.no) to play!
 ![highscore\_api](https://github.com/christianfosli/snake/workflows/highscore_api/badge.svg)
 ![highscore\_cleanup\_job](https://github.com/christianfosli/snake/workflows/highscore_cleanup_job/badge.svg)
 ![terraform](https://github.com/christianfosli/snake/actions/workflows/terraform.yml/badge.svg)
+![test_e2e](https://github.com/christianfosli/snake/actions/workflows/test_e2e.yaml/badge.svg)
 
 ## Architecture 🏗
 

--- a/e2e/.github/workflows/playwright.yml
+++ b/e2e/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,24 @@
+# End-to-End tests
+
+End to end tests for playwright
+
+## Prereq
+
+* NPM / Node
+
+* Install browsers needed for testing:
+
+  ```bash
+  npx playwright install
+  ```
+
+## Running tests
+
+```bash
+# Run headless against prod
+npx playwright test
+# Run headless against localhost (run app with docker-compose first :wink:)
+URL=localhost:8080 npx playwright test
+# Open UI for running interactively
+npx playwright test --ui
+```

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.36.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.2.tgz",
+      "integrity": "sha512-2rVZeyPRjxfPH6J0oGJqE8YxiM1IBRyM8hyrXYK7eSiAqmbNhxwcLa7dZ7fy9Kj26V7FYia5fh9XJRq4Dqme+g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.36.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
+      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.2.tgz",
+      "integrity": "sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "visnake-e2e",
+  "version": "1.0.0",
+  "description": "End to end tests for visnake",
+  "main": "index.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "^1.36.2"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/e2e/tests/test.spec.ts
+++ b/e2e/tests/test.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+const URL = process.env.URL ?? "https://www.playsnake.no";
+
+test('snake canvas appears', async ({ page }) => {
+  await page.goto(URL);
+  const canvas = page.locator('css=#phone canvas');
+  await canvas.waitFor();
+  expect(canvas).toBeAttached();
+});
+
+test('highscores load successfully', async ({page}) => {
+  await page.goto(URL);
+  // Initially no highscores appear
+  expect(page.getByText('Loading highscores...')).toHaveCount(2);
+
+  // Wait for highscores to be fetched
+  await page.waitForResponse(response => response.url().includes('topten'));
+  // Wait for a little bit longer
+  await page.waitForTimeout(500);
+
+  // Now highscore table should be rendered
+  expect(page.getByText('Loading highscores...')).toHaveCount(0);
+});


### PR DESCRIPTION
Adds end-to-end tests with PlayWright and corresponding pipeline.

Also adds `environment` tag to the different pipelines.
This allows us to trigger E2E tests when a deployment is created by one of the other pipelines.
It does not work 100% as intended yet (for example the E2E tests always target prod, but are triggered
by deployments to staging as well), but I think it's okay for now.