### PR TITLE
pipeline: fix deployment trigger for e2e tests

### DIFF
--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -2,6 +2,7 @@ name: test_e2e
 
 on:
   deployment:
+    environment: prod
   push:
     paths:
       - e2e/**


### PR DESCRIPTION
Adjust deployment trigger for e2e tests such that it
only triggers for deployments made to prod.

This is needed because we only test against prod.
Testing against staging would be complicated
because the URL's for PR deployments with Azure
static web apps are not deterministic.